### PR TITLE
Add include_directories for OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ if(USE_OPENMP)
      message(STATUS "Found OpenMP")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    include_directories("${OpenMP_CXX_INCLUDE_DIRS}")
+    include_directories("${OpenMP_C_INCLUDE_DIRS}")
   endif(NOT OPENMP_FOUND)
 endif(USE_OPENMP)
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This is needed on systems (such as clang on MacOS) that use non-standard locations of `omp.h`.

Fixes #109